### PR TITLE
Fix missing gizmo on some grenades and add compat for VWE-Non lethal and VFE Frontier

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -7,5 +7,6 @@
 	<v1.5>
 		<li>/</li>
 		<li>1.5/</li>
+		<li IfModActive="OskarPotocki.VanillaFactionsExpanded.SettlersModule">ModPatches/Vanilla Factions Expanded - Settlers</li>
 	</v1.5>
 </loadFolders>

--- a/ModPatches/Vanilla Factions Expanded - Settlers/Patches/RangedIndustrialGrenades.xml
+++ b/ModPatches/Vanilla Factions Expanded - Settlers/Patches/RangedIndustrialGrenades.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<!-- Add gizmo to VFE Settlers Dynamite -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VFES_Weapon_GrenadeDynamite"]/comps</xpath>
+		<value>
+			<li>
+				<compClass>AmogusGrenade.GizmoForNades</compClass>
+			</li>
+		</value>
+	</Operation>
+	
+	<!-- Remove the minimum range from the grenade -->
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="VFES_Weapon_GrenadeDynamite"]/verbs/li/minRange</xpath>
+	</Operation>
+</Patch>

--- a/Patches/AddOverheadComp.xml
+++ b/Patches/AddOverheadComp.xml
@@ -1,15 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-    <Operation Class="PatchOperationAdd">
-        <xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeEMP" or defName="Weapon_GrenadeFlashbang" or defName="Weapon_GrenadeSmoke" or defName="Weapon_GrenadeStickBomb" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeConcussion" or defName="Weapon_GrenadeFirefoam" or defName="Weapon_GrenadeTox" ]/comps</xpath>
-        <value>
-            <li>
-                <compClass>AmogusGrenade.GizmoForNades</compClass>
-            </li>
-        </value>
-    </Operation>
-
-    <Operation Class="PatchOperationRemove">
-        <xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeEMP" or defName="Weapon_GrenadeFlashbang" or defName="Weapon_GrenadeSmoke" or defName="Weapon_GrenadeStickBomb" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeConcussion" or defName="Weapon_GrenadeFirefoam"  or defName="Weapon_GrenadeTox" ]/verbs/li/minRange</xpath>
-    </Operation>
+	<!-- Make sure CE grenade parent class has <comps> -->
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[@Name="BaseGrenadeEquipment"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="BaseGrenadeEquipment"]</xpath>
+			<value>
+				<comps/>
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<!-- Make sure Vanilla grenade parent class has <comps>, in case any mods inherit from here -->
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[@Name="BaseMakeableGrenade"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="BaseMakeableGrenade"]</xpath>
+			<value>
+				<comps/>
+			</value>
+		</nomatch>
+	</Operation>
+	
+	<!-- Now that we know everything should have the comp node, we can add the gizmo -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeEMP" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeTox" or @Name="BaseGrenadeEquipment" or @Name="BaseMakeableGrenade"]/comps</xpath>
+		<value>
+			<li>
+				<compClass>AmogusGrenade.GizmoForNades</compClass>
+			</li>
+		</value>
+	</Operation>
+	
+	<!-- Remove the minimum range from the grenades -->
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeEMP" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeTox" or @ParentName="BaseGrenadeEquipment" or @ParentName="BaseMakeableGrenade"]/verbs/li/minRange</xpath>
+	</Operation>
 </Patch>


### PR DESCRIPTION
Currently the Concussion grenade and the stick bomb don't have the gizmo, this was because they don't have a `comps` node so instead of adding the gizmo to it, nothing happens.

I changed the way the patching works by patching parent classes higher up, but the vanilla nades don't have an easy parent so are dealt with individually. (no idea if this is actually good practice? It just seemed like a good idea)

The tear gas grenades from VWE -non lethal are dealt with by patching the vanilla grenade parent class, the way I understand things this should also add compatibility for any other nades that inherit from that.

Dynamite from the VFE - Frontier needed to be patched separately as it also has no specific parent, so I added a folder for that.

In my testing all the CE grenades and the other 2 mentioned ones now have the gizmo and seems to work as expected.
